### PR TITLE
removed "all_open" Application Security Group settings

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -20,8 +20,11 @@ The broker exposes the New Relic service on the Marketplace and allows users to 
 create a service instance and bind it to their apps either from Apps Manager or from the command line.
 
 The New Relic Service Broker for PCF tile installs the New Relic Service Broker as an app, 
-registers it as a service broker on PCF, and exposes its service plans on the Marketplace. 
+registers it as a service broker on PCF, and exposes its service plans on the Marketplace. The service plans each are associated with an existing New Relic account. So, selecting a plan would bind your app with New Relic agent, and the agent starts reporting to the New Relic account which is associated with the selected plan.
 This makes the installation and subsequent use of New Relic on your PCF apps more straightforward.
+
+
+**Note: ** The current tile removes **"all_open"** security group from the tile's default security settings. If users who were on previous versions of the tile would like to make their PCF environment more secure, they should remove the **"all_open"** security group from the ASG settings. The new version of the tile does not open the security, nor does it close it if it were already open.
 
 ##<a id='trial'></a>Trial License ##
 
@@ -36,7 +39,7 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.9.0</td>
+        <td>v1.9.1</td>
     </tr>
     <tr>
         <td>Release date</td>
@@ -44,15 +47,15 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Service Broker v1.9.0</td>
+        <td>New Relic Service Broker v1.9.1</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.8.x, v1.9.x</td>
+        <td>v1.8.x, v1.9.x, v1.10.x</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.8.x, v1.9.x</td>
+        <td>v1.8.x, v1.9.x, 1.10.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -63,7 +66,7 @@ The following table provides version and version-support information about New R
 ##<a id='upgrading'></a>Upgrading to the Latest Version ##
 
 Upgrade from v1.6 or v1.7 is supported. 
-Any older tile configuration in PCF Operations Manager (Ops Manager) v1.8 or v1.9 will show with older
+Any older tile configuration in PCF Operations Manager (Ops Manager) v1.8, v1.9, or v1.10 will show with older
 New Relic Service Broker for PCF tile version. 
 Any v1.6, v1.7 will have configuration that can be imported and carried forward when importing this tile.</dd>
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -24,7 +24,7 @@ registers it as a service broker on PCF, and exposes its service plans on the Ma
 This makes the installation and subsequent use of New Relic on your PCF apps more straightforward.
 
 
-**Note: ** The current tile removes **"all_open"** security group from the tile's default security settings. If users who were on previous versions of the tile would like to make their PCF environment more secure, they should remove the **"all_open"** security group from the ASG settings. The new version of the tile does not open the security, nor does it close it if it were already open.
+**Note: ** The current tile removes **"all_open"** security group from the tile's default security settings. If users who were on previous versions of the tile would like to make their PCF environment more secure, they should remove the **"all_open"** security group from the ASG settings. The new version of the tile does not open the security, nor does it close the security if it were already open.
 
 ##<a id='trial'></a>Trial License ##
 


### PR DESCRIPTION
New Relic tile v. 1.9.1
removed "all_open" ASG from tile's default settings, added support for PCF 1.10, updated docs.
