### PR TITLE
fixed version number of tile icon

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -51,7 +51,7 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Release date</td>
-        <td>August 16, 2017</td>
+        <td>August 29, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -32,7 +32,7 @@ If you are using a previous versions of the tile, make your PCF environment more
 removing the <code>all_open</code> security group from the Application Security Group (ASG) settings. 
 The new version of the tile does not open the security, nor does it close the security if it was already open.</p>
 
-<p class="note"><strong>Note</strong>: Removed the minor version number from stemcell criteria to allow users to apply stemcell security patches.
+<p class="note"><strong>Note</strong>: Removed the minor version number from stemcell criteria to allow users to apply stemcell security patches, and fixed the version number on the tile icon to match the tile version.
 
 ##<a id='trial'></a>Trial License ##
 
@@ -47,7 +47,7 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.11.1</td>
+        <td>v1.11.2</td>
     </tr>
     <tr>
         <td>Release date</td>
@@ -55,7 +55,7 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Service Broker v1.11.1</td>
+        <td>New Relic Service Broker v1.11.2</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>


### PR DESCRIPTION
fixed the tile version number in metadata to reflect the correct version on the tile icon in Ops Mgr.
