### PR TITLE
changed service broker's memory quota to 1024M

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -33,8 +33,12 @@ removing the <code>all_open</code> security group from the Application Security 
 The new version of the tile does not open the security, nor does it close the security if it was already open.</p>
 
 <p class="note"><strong>Note</strong>: Removed the minor version number from stemcell criteria to allow users 
-   to apply stemcell security patches, fixed the version number on the tile icon to match the tile version,
-   and fixed the upgrade path from PCF Operations Manager (Ops Manager) v1.9.x.
+to apply stemcell security patches, fixed the version number on the tile icon to match the tile version,
+and fixed the upgrade path from PCF Operations Manager (Ops Manager) v1.9.x.</p>
+
+<p class="note"><strong>Note</strong>: Bumped up memory quota from 512M to 1024M due to requirements for new version of java. Also increase memory quota range to 1024M-2048M.</p>
+
+
 
 ##<a id='trial'></a>Trial License ##
 
@@ -49,23 +53,23 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.11.3</td>
+        <td>v1.11.4</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>September 12, 2017</td>
+        <td>October 13, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Service Broker v1.11.3</td>
+        <td>New Relic Service Broker v1.11.4</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.9.x, v1.10.x, and v1.11.x</td>
+        <td>v1.9.x, v1.10.x, v1.11.x, and v1.12.x</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.9.x, v1.10.x, and v1.11.x</td>
+        <td>v1.9.x, v1.10.x, v1.11.x, and v1.12.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -75,7 +79,7 @@ The following table provides version and version-support information about New R
 
 ##<a id='upgrading'></a>Upgrading to the Latest Version ##
 
-The tile is supported on Ops Manager v1.9.x, v1.10.x, and v1.11.x.
+The tile is supported on Ops Manager v1.9.x, v1.10.x, v1.11.x, and , v1.12.x.
 You can install the tile on any of these versions.
 No upgrade paths required for older verisons of the tile, because versions older than v1.9.0 are not supported anymore.</dd>
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -6,6 +6,17 @@ owner: Partners
 
 These are release notes for New Relic Service Broker for PCF.
 
+##<a id="ver"></a> v1.11.4
+
+**Release Date:** October 13, 2017
+
+Features included in this release:
+
+* Bumped up memory quota for service broker from 512M to 1024M due to new java requirements
+* Bumped memory quota range from 512-1024  to 1024-2048
+* Updated the upgrade path from Ops Manager v1.9.0 and later to v1.12.x
+
+
 ##<a id="ver"></a> v1.11.3
 
 **Release Date:** September 12, 2017


### PR DESCRIPTION
1 - bumped up service broker's memory quota to 1024M.
2 - changed stemcell version to 3445 to support OpsMgr 1.12.
