### PR TITLE
added support for ops mgr 1.12 & migration from 1.11.x

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -63,11 +63,11 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Release date</td>
-        <td>October 30, 2017</td>
+        <td>November 10, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Service Broker v1.12.0</td>
+        <td>New Relic Service Broker v1.12.3</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -88,7 +88,7 @@ The following table provides version and version-support information about New R
 * The tile is supported on Ops Manager v1.9.x, v1.10.x, v1.11.x, and 1.12.x.
 * You can install the tile on any of these versions, and upgrade from 1.9.x to any Ops Mgr version up to and including 1.12.x.
 * No upgrade paths are required for older verisons of the tile, since versions older than v1.9.0 are not supported.
-* There is no upgrade path available from older versions of Ops Mgr to 1.12. You need to start fresh, or uninstall the older version of the tile, and install 1.12.0
+* Version 1.12.3 of the tile supports migration from older versions of the tile, and preserves exsiting services and service plans
 
 ##<a id='installing'></a> Install via Ops Manager ##
 

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -6,7 +6,16 @@ owner: Partners
 
 These are release notes for New Relic Service Broker for PCF.
 
-##<a id="ver"></a> v1.12.0
+##<a id="v1.12.3"></a> v1.12.3
+
+**Release Date:** November 10, 2017
+
+Features included in this release:
+
+* Added migration logic from all versions starting 1.9.x to 1.12
+
+
+##<a id="v1.12.0"></a> v1.12.0
 
 **Release Date:** October 30, 2017
 
@@ -15,7 +24,7 @@ Features included in this release:
 * Added support for Ops Mgr 1.12
 
 
-##<a id="ver"></a> v1.11.4
+##<a id="v1.11.4"></a> v1.11.4
 
 **Release Date:** October 16, 2017
 
@@ -25,7 +34,7 @@ Features included in this release:
 * Bumped memory quota range from 512–1024 to 1024–2048
 
 
-##<a id="ver"></a> v1.11.3
+##<a id="v1.11.3"></a> v1.11.3
 
 **Release Date:** September 12, 2017
 
@@ -34,7 +43,7 @@ Features included in this release:
 * Added upgrade path from Ops Manager v1.9.0 and later to v1.11.x
 
 
-##<a id="ver"></a> v1.11.2
+##<a id="v1.11.2"></a> v1.11.2
 
 **Release Date:** August 29, 2017
 
@@ -48,7 +57,7 @@ Fixed issues in this release:
 * Update stemcell to patch Ubuntu Linux kernel security vulnerability (USN-3385-2)
 * Fixed the version discrepancy
 
-##<a id="ver"></a> v1.11.1
+##<a id="v1.11.1"></a> v1.11.1
 
 **Release Date:** August 17, 2017
 
@@ -64,7 +73,7 @@ Known issues in this release:
 
 * File versioning Discrepency
 
-##<a id="ver"></a> v1.11.0
+##<a id="v1.11.0"></a> v1.11.0
 
 **Release Date:** August 1, 2017
 
@@ -76,7 +85,7 @@ Known issues in this release:
 
 * Ubuntu Linux kernel security vulnerability (USN-3385-2)
 
-##<a id="ver"></a> v1.9.1
+##<a id="v1.9.1"></a> v1.9.1
 
 **Release Date:** May 10, 2017
 
@@ -88,7 +97,7 @@ Fixed issues in this release:
 
 * CVE-2017-4975 fix
 
-##<a id="ver"></a> v1.8.1
+##<a id="v1.8.1"></a> v1.8.1
 
 **Release Date:** May 10, 2017
 
@@ -101,7 +110,7 @@ Fixed issues in this release:
 
 * CVE-2017-4975 fix
 
-##<a id="ver"></a> v1.7.1
+##<a id="v1.7.1"></a> v1.7.1
 
 **Release Date:** May 10, 2017
 
@@ -114,7 +123,7 @@ Fixed issues in this release:
 
 * CVE-2017-4975 fix
 
-##<a id="ver"></a> v1.9.0
+##<a id="v1.9.0"></a> v1.9.0
 
 **Release Date:** March 3, 2017
 
@@ -126,7 +135,7 @@ Known issues in this release:
 
 * CVE-2017-4975 
 
-##<a id="ver"></a> v1.1.0
+##<a id="v1.1.0"></a> v1.1.0
 
 **Release Date:** September 30, 2016
 
@@ -134,7 +143,7 @@ Features included in this release:
 
 * This version of New Relic tile support Ops Manager v1.7 and v1.8.
 
-##<a id="ver"></a> v1.0
+##<a id="v1.0"></a> v1.0
 
 **Release Date:** December 16, 2015
 


### PR DESCRIPTION
added migration logic from 1.11.x to 1.12. The migration preserves all new relic services and service instances which were created with the older version of the tile.