### PR TITLE
added tile version 1.12.6

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -44,6 +44,7 @@ and fixed the upgrade path from PCF Operations Manager (Ops Manager) v1.9.x.</p>
 
 <p class="note"><strong>Note</strong>: Upgraded the tile to support Ops Mgr 1.12.x.</p>
 
+<p class="note"><strong>Note</strong>: This release includes fixes for migration from tile 1.11.4 on Ops Mgr 1.11.x to Ops Mgr 1.12.x. It also includes 2 improvements: enabling global access by default, and adding support for multi-subnet networks.</p>
 
 
 ##<a id='trial'></a>Trial License ##
@@ -59,15 +60,15 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.12.3</td>
+        <td>v1.12.6</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 10, 2017</td>
+        <td>November 18, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Service Broker v1.12.3</td>
+        <td>New Relic Service Broker v1.12.6</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -88,7 +89,7 @@ The following table provides version and version-support information about New R
 * The tile is supported on Ops Manager v1.9.x, v1.10.x, v1.11.x, and 1.12.x.
 * You can install the tile on any of these versions, and upgrade from 1.9.x to any Ops Mgr version up to and including 1.12.x.
 * No upgrade paths are required for older verisons of the tile, since versions older than v1.9.0 are not supported.
-* Version 1.12.3 of the tile supports migration from older versions of the tile, and preserves exsiting services and service plans
+* Version 1.12.6 of the tile supports migration from older versions of the tile, and preserves exsiting services and service plans
 
 ##<a id='installing'></a> Install via Ops Manager ##
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -64,7 +64,7 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 18, 2017</td>
+        <td>November 20, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -6,6 +6,22 @@ owner: Partners
 
 These are release notes for New Relic Service Broker for PCF.
 
+##<a id="v1.12.6"></a> v1.12.6
+
+**Release Date:** November 18, 2017
+
+Features included in this release:
+
+* fixed error: not able to delete the service broker due to service instances being associated with it
+* fixed problem not transferring service instances from the old tile to the new one
+* fixed error in Apps Mgr when trying to create a service instance (tile 1.11.4 on PCF 1.12)
+* fixed error when trying to upload service broker 1.12.5 to Ops Mgr
+* enabled global access so all orgs/spaces have access to the tile
+* enabled support for multi-subnet networks
+
+
+These are release notes for New Relic Service Broker for PCF.
+
 ##<a id="v1.12.3"></a> v1.12.3
 
 **Release Date:** November 10, 2017

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -8,7 +8,7 @@ These are release notes for New Relic Service Broker for PCF.
 
 ##<a id="v1.12.6"></a> v1.12.6
 
-**Release Date:** November 18, 2017
+**Release Date:** November 20, 2017
 
 Features included in this release:
 


### PR DESCRIPTION
in version 1.12.6 of the tile there are fixes for migration from tile 1.11.4 on older versions of ops mgr to ops mgr 1.12.x. it transfers existing service instances if upgraded from older versions of ops mgr.

additionally the new release includes 2 improvements:
1 - set default value for global access to true
2 - add support for multi-subnet networks on AWS

thank you
